### PR TITLE
feat: improve project image handling and remove gradient fields

### DIFF
--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -47,7 +47,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
     <>
       <PageHero
         title={project.title}
-        backgroundImage={project.images[0]?.asset.url || '/placeholder.svg'}
+        backgroundImage={project.images[0]?.asset?.url || '/placeholder.svg'}
       />
 
       <Container className="px-4 py-8 relative">
@@ -89,7 +89,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
                           className="aspect-[4/3] overflow-hidden rounded-lg"
                         >
                           <Image
-                            src={img.asset.url || '/placeholder.svg'}
+                            src={img.asset?.url || '/placeholder.svg'}
                             alt={`${project.title} image ${index + 1}`}
                             width={800}
                             height={600}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -34,14 +34,22 @@ export default async function ProjectsPage() {
                 className="overflow-hidden border-0 custom-shadow shadow-none p-0 hover:shadow-lg transition-shadow"
               >
                 <div className="aspect-[16/9] overflow-hidden relative">
-                  {project.images && project.images.length > 0 && (
+                  {project.images &&
+                  project.images.length > 0 &&
+                  project.images[0]?.asset?.url ? (
                     <Image
-                      src={project.images[0].asset.url || '/placeholder.svg'}
+                      src={project.images[0].asset.url}
                       alt={project.title}
                       fill
                       className="hover:scale-105 object-cover"
                       sizes="(max-width: 768px) 100vw, (max-width: 1200px) 66vw, 50vw"
                     />
+                  ) : (
+                    <div className="w-full h-full bg-muted flex items-center justify-center">
+                      <span className="text-muted-foreground">
+                        No image available
+                      </span>
+                    </div>
                   )}
                 </div>
                 <CardContent className="p-6">

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -50,7 +50,9 @@ const HeroSection = React.memo(function HeroSection() {
       id: `project-${project._id}`,
       title: project.title,
       image:
-        project.images && project.images.length > 0
+        project.images &&
+        project.images.length > 0 &&
+        project.images[0]?.asset?.url
           ? project.images[0].asset.url
           : '/images/olooji-community.jpg?height=800&width=1400', // fallback
       location: project.location,

--- a/components/sections/projects-section.tsx
+++ b/components/sections/projects-section.tsx
@@ -83,14 +83,24 @@ export function ProjectsSection() {
       <div className="text-center mb-12">
         <MaskText
           phrases={[
-            'Latest Rural Electrification Projects,',
+            'Latest 3 Rural Electrification Projects,',
             'Mini-Grid Solutions & Energizing Supplies',
           ]}
           className="text-3xl md:text-4xl font-bold text-foreground transition-colors duration-700"
         />
       </div>
-      {projects.map((project, i) => {
-        const targetScale = 1 - (projects.length - i) * 0.05;
+      {projects.slice(0, 3).map((project, i) => {
+        const targetScale = 1 - (3 - i) * 0.05;
+
+        // Alternating gradient configuration: gray, green, gray, green, etc.
+        const gradients = [
+          { from: '#616161', to: '#000000' }, // 1st card - Gray
+          { from: '#08913F', to: '#003808' }, // 2nd card - Green
+          { from: '#616161', to: '#000000' }, // 3rd card - Gray
+        ];
+
+        const gradientConfig = gradients[i];
+
         return (
           <Card
             key={`p_${project._id}`}
@@ -99,8 +109,8 @@ export function ProjectsSection() {
             description={project.description}
             images={project.images}
             location={project.location}
-            gradientFrom={project.gradientFrom}
-            gradientTo={project.gradientTo}
+            gradientFrom={gradientConfig.from}
+            gradientTo={gradientConfig.to}
             url={`/projects/${project.slug.current}`}
             progress={scrollYProgress}
             range={[i * 0.25, 1]}

--- a/components/ui/stack-cards.tsx
+++ b/components/ui/stack-cards.tsx
@@ -73,7 +73,9 @@ const Card: React.FC<CardProps> = ({
               </h2>
 
               <p className="text-base lg:text-xl leading-relaxed line-clamp-3 md:line-clamp-none">
-                {description}
+                {description.split(' ').length > 40
+                  ? `${description.split(' ').slice(0, 40).join(' ')}...`
+                  : description}
               </p>
 
               <p className="flex gap-2 text-lg items-center">
@@ -95,37 +97,85 @@ const Card: React.FC<CardProps> = ({
           </div>
 
           {/* Image Section */}
-          <div className="w-full sm:w-1/2 h-full flex-1 grid grid-rows-2 grid-cols-2 gap-4 rounded-[20px] overflow-hidden">
-            {images[0] && (
-              <div className="row-span-1 col-span-2 relative rounded-[16px] overflow-hidden">
-                <Image
-                  src={images[0].asset.url || '/placeholder.svg'} // Use Sanity image URL
-                  alt={title}
-                  fill
-                  className="object-cover"
-                />
-              </div>
-            )}
-            {images[1] && (
-              <div className="relative rounded-[16px] overflow-hidden">
-                <Image
-                  src={images[1].asset.url || '/placeholder.svg'} // Use Sanity image URL
-                  alt={title}
-                  fill
-                  className="object-cover"
-                />
-              </div>
-            )}
-            {images[2] && (
-              <div className="relative rounded-[16px] overflow-hidden">
-                <Image
-                  src={images[2].asset.url || '/placeholder.svg'} // Use Sanity image URL
-                  alt={title}
-                  fill
-                  className="object-cover"
-                />
-              </div>
-            )}
+          <div className="w-full sm:w-1/2 h-full flex-1 rounded-[20px] overflow-hidden">
+            {(() => {
+              const validImages = images.filter(img => img?.asset?.url);
+
+              if (validImages.length === 1) {
+                // Single image - full height
+                return (
+                  <div className="relative rounded-[16px] overflow-hidden h-full">
+                    <Image
+                      src={validImages[0].asset.url}
+                      alt={title}
+                      fill
+                      className="object-cover"
+                    />
+                  </div>
+                );
+              } else if (validImages.length === 2) {
+                // Two images - side by side
+                return (
+                  <div className="grid grid-cols-2 gap-4 h-full">
+                    <div className="relative rounded-[16px] overflow-hidden">
+                      <Image
+                        src={validImages[0].asset.url}
+                        alt={title}
+                        fill
+                        className="object-cover"
+                      />
+                    </div>
+                    <div className="relative rounded-[16px] overflow-hidden">
+                      <Image
+                        src={validImages[1].asset.url}
+                        alt={title}
+                        fill
+                        className="object-cover"
+                      />
+                    </div>
+                  </div>
+                );
+              } else if (validImages.length >= 3) {
+                // Three or more images - grid layout
+                return (
+                  <div className="grid grid-rows-2 grid-cols-2 gap-4 h-full">
+                    <div className="row-span-1 col-span-2 relative rounded-[16px] overflow-hidden">
+                      <Image
+                        src={validImages[0].asset.url}
+                        alt={title}
+                        fill
+                        className="object-cover"
+                      />
+                    </div>
+                    <div className="relative rounded-[16px] overflow-hidden">
+                      <Image
+                        src={validImages[1].asset.url}
+                        alt={title}
+                        fill
+                        className="object-cover"
+                      />
+                    </div>
+                    <div className="relative rounded-[16px] overflow-hidden">
+                      <Image
+                        src={validImages[2].asset.url}
+                        alt={title}
+                        fill
+                        className="object-cover"
+                      />
+                    </div>
+                  </div>
+                );
+              } else {
+                // No images - placeholder
+                return (
+                  <div className="h-full bg-muted/20 rounded-[16px] flex items-center justify-center">
+                    <span className="text-muted-foreground">
+                      No images available
+                    </span>
+                  </div>
+                );
+              }
+            })()}
           </div>
         </div>
       </motion.div>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -35,8 +35,6 @@ export interface Project {
   };
   description: string;
   location: string;
-  gradientFrom: string;
-  gradientTo: string;
   images: SanityImageUrl[];
   _createdAt: string;
   _updatedAt: string;

--- a/sanity/lib/client.ts
+++ b/sanity/lib/client.ts
@@ -114,8 +114,6 @@ export async function getProjects() {
         slug,
         description,
         location,
-        gradientFrom,
-        gradientTo,
         images[]{
           asset->{url}
         }
@@ -138,8 +136,6 @@ export async function getProject(slug: string) {
         slug,
         description,
         location,
-        gradientFrom,
-        gradientTo,
         images[]{
           asset->{url}
         }

--- a/sanity/schemaTypes/project.ts
+++ b/sanity/schemaTypes/project.ts
@@ -49,25 +49,13 @@ export const projectType = defineType({
           ],
         },
       ],
-      validation: Rule => Rule.min(1).required(),
+      validation: Rule => Rule.min(1).max(6).required(),
     }),
     defineField({
       name: 'location',
       title: 'Location',
       type: 'string',
       validation: Rule => Rule.required(),
-    }),
-    defineField({
-      name: 'gradientFrom',
-      title: 'Gradient Start Color (Hex)',
-      type: 'string',
-      description: 'e.g., #08913F',
-    }),
-    defineField({
-      name: 'gradientTo',
-      title: 'Gradient End Color (Hex)',
-      type: 'string',
-      description: 'e.g., #003808',
     }),
   ],
   preview: {


### PR DESCRIPTION
- Remove gradient fields from Sanity project schema
- Implement local gradient handling in projects section
- Fix image display issues for projects with 1-3 images
- Add proper null checks for image assets
- Limit projects section to show only 3 latest projects
- Add alternating gradient pattern (gray/green/gray)
- Update TypeScript types to remove gradient fields
- Fix image layout in stack-cards component
- Add 40-word limit for project descriptions
- Improve error handling for missing images